### PR TITLE
chore: add output for ID of VPC internet gateway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra_plugins: |
+            @semantic-release/git@7.0.18
+            @semantic-release/exec@3.3.8
+            @semantic-release/changelog@3.0.0

--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -36,12 +36,3 @@ jobs:
         run: |
           cd test
           go test -v -timeout 30m
-      - name: Release
-        uses: cycjimmy/semantic-release-action@v2
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          extra_plugins: |
-            @semantic-release/git@7.0.18
-            @semantic-release/exec@3.3.8
-            @semantic-release/changelog@3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ Temporary Items
 *.tfstate
 *.tfstate.*
 
+# files related to external terraform modules
+.external_modules/ 
+
 # Crash log files
 crash.log
 

--- a/aws-vpc/outputs.tf
+++ b/aws-vpc/outputs.tf
@@ -22,3 +22,13 @@ output "vpc_id" {
   description = "AWS identifier for the VPC provisioned by this module"
   value       = module.vpc.vpc_id
 }
+
+output "igw_id" {
+  description = "AWS identifier for the Internet gateway at VPC level"
+  value       = module.vpc.igw_id
+}
+
+output "igw_arn" {
+  description = "AWS ARN for the Internet gateway at VPC level"
+  value       = module.vpc.igw_arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,13 @@ output "vpc_id" {
   description = "AWS identifier for the VPC provisioned by this module"
   value       = module.aws-vpc.vpc_id
 }
+
+output "igw_id" {
+  description = "AWS identifier for the Internet gateway at VPC level"
+  value       = module.aws-vpc.igw_id
+}
+
+output "igw_arn" {
+  description = "AWS ARN for the Internet gateway at VPC level"
+  value       = module.aws-vpc.igw_arn
+}


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!

* To reference an issue in your PR, add a suffix with the format `[ISSUE_ID_1, ISSUE_ID_2, ...]`

* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

Adds an output for the ID of the internet gateway that is used in the VPC. This will be consumed by other modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-vpc/6)
<!-- Reviewable:end -->
